### PR TITLE
Fix compilation errors when compiling with Scala 3.3.x

### DIFF
--- a/modules/core/src/main/scala/gql/Planner.scala
+++ b/modules/core/src/main/scala/gql/Planner.scala
@@ -317,7 +317,7 @@ object Planner {
   )
 
   object Children {
-    implicit val monoid = new Monoid[Children] {
+    implicit val monoid: Monoid[Children] = new Monoid[Children] {
       override def empty: Children = Children(Set.empty, Set.empty)
 
       override def combine(x: Children, y: Children): Children =

--- a/modules/core/src/test/scala/gql/PlannerTest.scala
+++ b/modules/core/src/test/scala/gql/PlannerTest.scala
@@ -33,7 +33,7 @@ class PlannerTest extends CatsEffectSuite {
   )
   object PlannerState {
     implicit def monoidForPlannerState: cats.Monoid[PlannerState] = new cats.Monoid[PlannerState] {
-      implicit def semigroupForTreeSet[A] = new Semigroup[TreeSet[A]] {
+      implicit def semigroupForTreeSet[A]: Semigroup[TreeSet[A]] = new Semigroup[TreeSet[A]] {
         def combine(x: TreeSet[A], y: TreeSet[A]): TreeSet[A] = x ++ y
       }
 


### PR DESCRIPTION
Add required type annotations for implicit values. Implicits since Scala 3.0.x require explicit result type, probably there were a non-fatal warnings about that in the past. 

This issue was found in the Scala 3 Open Community Build: https://github.com/VirtusLab/community-build3/actions/runs/4326874158/jobs/7559568753