### PR TITLE
Fix compilation when using Scala 3.3.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,6 +145,7 @@ lazy val clientCodegenSbt = project
   .settings(
     sbtPlugin := true,
     scalaVersion := "2.12.17",
+    crossScalaVersions := Nil,
     name := "gql-client-codegen-sbt"
   )
   .aggregate(clientCodegenCli)

--- a/modules/client/src/main/scala/gql/client/QueryValidation.scala
+++ b/modules/client/src/main/scala/gql/client/QueryValidation.scala
@@ -104,14 +104,16 @@ object QueryValidation {
     def implementation[A](s: String): EitherNec[String, Implementation[Pure, A, ?]] =
       partitionType(s).flatMap {
         case i: InterfaceType =>
-          Right(Implementation(Eval.always(convertInterface(i).toOption.get))(_ => Option.empty[A]))
+          for (impl <- convertInterface(i))
+            yield Implementation(Eval.always(impl))(_ => Option.empty[A])
         case _ => s"Expected interface, got object `${s}`".leftNec
       }
 
     def variant[A](s: String) =
       partitionType(s).flatMap {
         case i: ObjectType =>
-          Right(Variant(Eval.always(convertObject(i).toOption.get))((_: Unit) => None))
+          for (tpe <- convertObject(i))
+            yield Variant(Eval.always(tpe))((_: Unit) => None)
         case _ => s"Expected object type, got something else `${s}`".leftNec
       }
 


### PR DESCRIPTION
Fix compilation when using Scala 3.3.x due to introduced source compatibilty breakages: by-name parameter used a wildcard type and was not defined as a value - it's no longer allowed as it can lead to unsoundness.

Based on the Open Community Build results: https://github.com/VirtusLab/community-build3/actions/runs/4650721329/jobs/8231981628
